### PR TITLE
Add agent instructions and Copilot config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot – Project-specific Guidance
+- For instructions related to Agents, refer to AGENTS.md.
+- For documentation regarding the System, consult the Markdown files located under the /docs directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This repository uses Node.js 18+ and pnpm for dependency management.
+
+- Install dependencies with `pnpm install`.
+- Start the development server with `pnpm start`.
+- Build the static site using `pnpm build`.
+- Run `pnpm typecheck` to verify TypeScript types.
+
+For detailed setup and usage information, see [docs/agent-guide.md](docs/agent-guide.md).

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,41 @@
+# Agent Guide
+
+This project uses [Docusaurus](https://docusaurus.io/) to generate a documentation website.
+
+## Requirements
+
+- Node.js 18 or later
+- pnpm
+
+## Setup
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+## Development
+
+Start the local development server:
+
+```bash
+pnpm start
+```
+
+## Build
+
+Generate the static site:
+
+```bash
+pnpm build
+```
+
+## Type Checking
+
+Run the TypeScript compiler to verify types:
+
+```bash
+pnpm typecheck
+```
+


### PR DESCRIPTION
## Summary
- add AGENTS setup notes
- document agent configuration in docs/agent-guide.md
- create copilot guidance for the repo

## Testing
- `pnpm install`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@docusaurus/theme-classic')*

------
https://chatgpt.com/codex/tasks/task_e_6843f03461b483299efeb64775aff329